### PR TITLE
Add endpoint reference links to API documentation

### DIFF
--- a/app/views/_http_example.html.erb
+++ b/app/views/_http_example.html.erb
@@ -5,4 +5,17 @@
     <span class="http-box-method"><%= method %></span>
     <span class="http-box-url"><%= url %></span>
   </div>
+
+  <%
+    active_link = 'https://docs.mx.com'
+    displayed_text = 'MX API reference docs'
+
+    if local_assigns.has_key? :href
+      active_link = href
+      displayed_text = 'Endpoint reference'
+    end
+  %>
+
+  <br>
+  <a href="<%= active_link %>" target="_blank"><%= displayed_text %></a>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,11 @@
 <h1>Create an MX User</h1>
 
-<%= render "/http_example", description: "To create an MX user you send an http message to:", method: "POST", url: "/users" %>
+<%= render "/http_example", 
+  description: "To create an MX user you send an http message to:", 
+  method: "POST", 
+  url: "/users", 
+  href: "https://docs.mx.com/api#core_resources_users_create_user" 
+%>
 
 <p>Fill in a few small pieces of information to create a user<p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,7 +21,12 @@
         <li>Use the widget url in the Widget Loader to render it on the page</li>
     </ol>
 
-    <%= render "/http_example", description: "To generate a widget URL, you send an http message to:", method: "POST", url: "/users/{user_guid}/widget_urls" %>
+    <%= render "/http_example", 
+      description: "To generate a widget URL, you send an http message to:", 
+      method: "POST", 
+      url: "/users/{user_guid}/widget_urls",
+      href: "https://docs.mx.com/api#connect_request_a_url"
+    %>
 
     <p>(optional) If you want to see what a URL looks like, click the button to call the endpoint above.</p>
     <button id="gen-url">Generate a URL</button>
@@ -32,7 +37,12 @@
 
     <p>Click the button below to see what accounts have been connected to MX</p>
 
-    <%= render "/http_example", description: "To list a user's accounts send an http message to:", method: "GET", url: "/users/{user_guid}/accounts" %>
+    <%= render "/http_example",
+      description: "To list a user's accounts send an http message to:", 
+      method: "GET", 
+      url: "/users/{user_guid}/accounts",
+      href: "https://docs.mx.com/api#core_resources_accounts_list_accounts"
+    %>
     
     <button id="load-accounts">Load User Accounts</button>
 
@@ -61,7 +71,12 @@
 
     <p>Now the app needs display a list of verified accounts, so the user can generate an authorization code</p>
 
-    <%= render "/http_example", description: "To list account numbers that have been verified, send an http message to:", method: "GET", url: "/users/{user_guid}/members/{member_guid}/account_numbers" %>
+    <%= render "/http_example",
+      description: "To list account numbers that have been verified, send an http message to:", 
+      method: "GET", 
+      url: "/users/{user_guid}/members/{member_guid}/account_numbers",
+      href: "https://docs.mx.com/api#verification_mx_widgets_list_account_numbers_by_member"
+    %>
 
     <button id="load-verified-accounts">Load User Accounts</button>
 
@@ -69,7 +84,11 @@
 
     <p>Once the list loads up, you can click the "Generate Auth Code" button to request a code for that account</p>
 
-    <%= render "/http_example", description: "To get an account authorization code, send an http message to:", method: "POST", url: "/payment_processor_authorization_code" %>
+    <%= render "/http_example",
+      description: "To get an account authorization code, send an http message to:", 
+      method: "POST", 
+      url: "/payment_processor_authorization_code"
+    %>
 
 </section>
 


### PR DESCRIPTION
This adds a clickable reference link to the API docs for the specified endpoint.  The goal here is to fill in the details that may not be visible at a glance.