### PR TITLE
Add reference to the auth code documentation

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -160,7 +160,8 @@
             title: "Generate an Authorization Code",
             description: "This endpoint will generate an authorization code for one specific account.  This is the endpoint called by the Generate Auth Code button in the above table",
             method: "POST",
-            url: "/payment_processor_authorization_code"
+            url: "/payment_processor_authorization_code",
+            href: "https://docs.mx.com/api#processor_token_authorization_code"
         %>
     </div>
 


### PR DESCRIPTION
The documentation team provided me with the link to the documentation that will go live with the feature: https://docs.mx.com/api#processor_token_authorization_code

#### Testing Instructions

1. Run the app.
2. Create or select an existing user.
3. Scroll to the bottom of the page.
4. Find the API reference section titled "Generate an Authorization Code", and click the "Visit the docs to learn more." link
5. You should be directed to an API reference link: https://docs.mx.com/api#processor_token_authorization_code (This section of the docs isn't live yet, so you'll have to check the URL in the browser.  On launch day it will have content).