### PR TITLE
Update client token endpoint reference

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -161,7 +161,7 @@
             description: "This endpoint will generate an authorization code for one specific account.  This is the endpoint called by the Generate Auth Code button in the above table",
             method: "POST",
             url: "/payment_processor_authorization_code",
-            href: "https://docs.mx.com/api#processor_token_authorization_code"
+            href: "https://docs.mx.com/api#processor_token_client_endpoints_authorization_code"
         %>
     </div>
 


### PR DESCRIPTION
The docs that are live now give reference to some Processor Token endpoints.

Our current quickstart app has reference to a page anchor that does not exist in the live docs.  This change updates the hyperlink to go to the right place in the live docs where the user can learn more about the endpoint.

#### Testing Instructions
1. Test that the old hyperlink doesn't bring the user to the right place: https://docs.mx.com/api#processor_token_authorization_code
2. Test that the new hyperlink brings the user to the right place, and give information about the `processor_token_authorization_code` https://docs.mx.com/api#processor_token_client_endpoints_authorization_code